### PR TITLE
Fix md files

### DIFF
--- a/docs/src/tutorials/LinearElastic/linear_elastic.md
+++ b/docs/src/tutorials/LinearElastic/linear_elastic.md
@@ -1,0 +1,15 @@
+# Linear Elastic Solid
+
+In this tutorial we consider a linear elastic solid submitted to uniaxial loading.
+The geometry given by $L_x$, $L_y$ and $L_z$, and a tension $p$ is applied on
+the face at $x=L_x$, see the diagram below.
+
+!!! note "TO-DO"
+    Continue the tutorial as in the [User Guide](https://www.fing.edu.uy/~jorgepz/onsas/mainUserGuide.html).
+
+We begin by defining the structural properties of the mesh.
+
+The material properties of the model are defined by the MELCS parameters. In this case a SVK material is considered.
+
+This model can be solved analytically and the result shows a good match between
+the analytic result and the numerical solution obtained with ONSAS.

--- a/docs/src/tutorials/SimplePendulum/simple_pendulum.md
+++ b/docs/src/tutorials/SimplePendulum/simple_pendulum.md
@@ -1,0 +1,24 @@
+# Simple pendulum
+
+## Model
+
+In this tutorial we study a simple pendulum. The model
+has one truss element. This model is taken from [^BATHE].
+
+|Parameter | Value|
+|-------|----|
+|Es | 10e11 |
+| nu | 0 |
+| A   | 0.1 |
+| l0  | 3.0443 |
+| m   | 10     |
+| g   | 9.81   |
+
+## Result
+
+!!! note "TO-DO"
+    Add results.
+
+## References
+
+[^BATHE]: Bathe, Klaus-Jürgen. Finite element procedures. Klaus-Jurgen Bathe, 2006.


### PR DESCRIPTION
This PR is just a fix for the WIP pages linear elastic and simple pendulum. The source is now plain markdown files instead of literate files. I think we can stick to this convention until we want to use more advanced Literate.jl capabilities such as automatic conversion to jupyter notebooks.  
