### PR TITLE
Read references from bib file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           version: 1.5
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.add("https://github.com/lucianolorenti/BibTeXFormat.jl.git"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.add(url="https://github.com/lucianolorenti/BibTeXFormat.jl.git"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           version: 1.5
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.add("https://github.com/lucianolorenti/BibTeXFormat.jl.git"); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Manifest.toml
 docs/build/
 docs/site/
+docs/src/_biblio.bib
+docs/src/references.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ jobs:
       os: linux
       script:
         - julia --project --color=yes --check-bounds=yes -e 'using Pkg; Pkg.instantiate()';
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+        - julia --project=docs/ -e 'using Pkg; Pkg.add(url="https://github.com/lucianolorenti/BibTeXFormat.jl.git");
+                                               Pkg.develop(PackageSpec(path=pwd()));
                                                Pkg.instantiate();'
         - travis_wait 25 julia --project=docs/ docs/make.jl
       after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+BibTeX = "7b0aa2c9-049f-5cec-894a-2b6b781bb25e"
+BibTeXFormat = "81872a04-5f92-5ce1-a30b-528d3f2b00a0"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/bibliography.jl
+++ b/docs/bibliography.jl
@@ -1,0 +1,51 @@
+using BibTeX, BibTeXFormat, Markdown
+using BibTeXFormat: change_case
+
+bibpath = joinpath(@__DIR__, "src/biblio.bib")
+_bibpath = joinpath(@__DIR__, "src/_biblio.bib")
+
+# pre-processing step to transform @book into @booklet entries
+# (current limitation of BibTeXFormat)
+open(_bibpath, "w") do f
+    for line in readlines(bibpath)
+        if startswith(line, "@book{")
+            println(f, replace(line, "@book{" => "@booklet{", count=1))
+        else
+            println(f, line)
+        end
+    end
+end
+
+# extract contents and convert to markdown
+bibliography = Bibliography(read(open(_bibpath), String))
+formatted_entries = format_entries(AlphaStyle, bibliography)
+
+cites = Vector{String}()
+contents = Vector{Markdown.MD}()
+for ei in formatted_entries
+    # format keys as eg. [BAB93]
+    k = change_case(ei[end], 'u')
+    kred = k[1:end-3] * k[end-1:end]
+    push!(cites, kred)
+
+    # content string formatting
+    x = write_to_string(MarkdownBackend(), ei)
+    x = replace(x, match(r"\[(.*?)\]", x).match => "") |> strip |> Markdown.parse
+
+    push!(contents, x)
+end
+
+BIBLIOGRAPHY = Dict(cites .=> contents)
+
+# write references markdown file
+refpath = joinpath(@__DIR__, "src/references.md")
+
+open(refpath, "w") do f
+    println(f, "# References\n")
+
+    for (i, ci) in enumerate(cites)
+        println(f, "---\n")
+        println(f, "### [$ci]\n")
+        println(f, "- ", contents[i])
+    end
+end

--- a/docs/bibliography.jl
+++ b/docs/bibliography.jl
@@ -35,7 +35,7 @@ for ei in formatted_entries
     push!(contents, x)
 end
 
-BIBLIOGRAPHY = Dict(cites .=> contents)
+const BIBLIOGRAPHY = Dict(cites .=> contents)
 
 # write references markdown file
 refpath = joinpath(@__DIR__, "src/references.md")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,19 +3,22 @@ using Documenter, ONSAS_Tutorials
 DocMeta.setdocmeta!(ONSAS_Tutorials, :DocTestSetup,
                     :(using ONSAS_Tutorials); recursive=true)
 
-# Generate tutorials
+# Generate notebooks
 #include("generate.jl")
+
+# Generate bibliography
+include("bibliography.jl")
 
 makedocs(
     sitename = "ONSAS_Tutorials",
     modules = [ONSAS_Tutorials],
-    #source="..",
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
     pages = [
         "Home" => "index.md",
         "Tutorials" => Any["Linear elastic solid" => "tutorials/LinearElastic/linear_elastic.md",
                            "Simple pendulum" => "tutorials/SimplePendulum/simple_pendulum.md",
                            "Heat diffusion" => "tutorials/HeatDiffusion/heat.md"],
+        "References" => "references.md",
         "About" => "about.md"
     ],
     strict = false

--- a/docs/src/biblio.bib
+++ b/docs/src/biblio.bib
@@ -1,0 +1,11 @@
+@book{Bathe2014,
+annote = {0031},
+author = {Bathe, Klaus-Jurgen},
+edition = {2},
+isbn = {9780979004957},
+pages = {1037},
+publisher = {Prentice-Hall},
+title = {{Finite Element Procedures}},
+url = {http://web.mit.edu/kjb/www/Books/FEP{\_}2nd{\_}Edition{\_}4th{\_}Printing.pdf},
+year = {2014}
+}

--- a/docs/src/tutorials/SimplePendulum/simple_pendulum.md
+++ b/docs/src/tutorials/SimplePendulum/simple_pendulum.md
@@ -18,7 +18,3 @@ has one truss element. This model is taken from [[BAT14]](@ref).
 
 !!! note "TO-DO"
     Add results.
-
-# References
-
-```@bibliography```

--- a/docs/src/tutorials/SimplePendulum/simple_pendulum.md
+++ b/docs/src/tutorials/SimplePendulum/simple_pendulum.md
@@ -3,7 +3,7 @@
 ## Model
 
 In this tutorial we study a simple pendulum. The model
-has one truss element. This model is taken from [^BATHE].
+has one truss element. This model is taken from [[BAT14]](@ref).
 
 |Parameter | Value|
 |-------|----|
@@ -19,6 +19,6 @@ has one truss element. This model is taken from [^BATHE].
 !!! note "TO-DO"
     Add results.
 
-## References
+# References
 
-[^BATHE]: Bathe, Klaus-Jürgen. Finite element procedures. Klaus-Jurgen Bathe, 2006.
+```@bibliography```


### PR DESCRIPTION
This PR reads the LaTeX references stored in the `biblio.bib` file and generates the `references.md` file. There is an intermediate `_biblio.bib` file to workaround a problem with `@book` entries that I found using `BibTeXFormat.jl`. Moreover, parsing some special characters is not working so I had to manually change eg. `Klaus-J{\"{u}}rgen` to `Klaus-Jurgen` in the `biblio.bib` file. This may be not hard to fix with the `Markdown` module but we can try that later.  

Note: I thought it would be easier with https://github.com/ali-ramadhan/DocumenterBibliographyTest.jl/ but I didn't get it to work as desired. Maybe the workflow will greatly simplify in the future once such tool is supplied as a Documenter plugin.
